### PR TITLE
Catch unavailable status

### DIFF
--- a/magister-school-card.js
+++ b/magister-school-card.js
@@ -351,7 +351,8 @@ class MagisterSchoolCard extends LitElement {
   }
 
   render() {
-    if (!this._data) {
+    const entityState = this.hass?.states?.[this.config.entity]?.state;
+    if (!this._data || entityState === 'unavailable' || entityState === 'unknown') {
       return html`
         <div class="card">
           <div class="empty-state">📚 School data laden...</div>


### PR DESCRIPTION
Bij het debuggen had ik eventjes de integratie code stuk waardoor de entities op 'unavailable' kwamen te staan.

Dat geeft voor het rooster dan 'Geen lessen vandaag 🎉' ... wat onhandige verwarring kan opleveren.

De patch vangt die conditie ook af.